### PR TITLE
feat: upgrade dependencies and workflows to latest versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: "21"
+          distribution: "temurin"
       - run: gradle build
       - run: gradle test

--- a/.github/workflows/discord-notification.yaml
+++ b/.github/workflows/discord-notification.yaml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: "Ilshidur/action-discord@0.3.0"
+      - uses: "Ilshidur/action-discord@0.3.2"
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         if: ${{ github.event_name == 'pull_request' }}
@@ -24,7 +24,7 @@ jobs:
             A new PR {{ EVENT_PAYLOAD.pull_request.title }}
             by {{ EVENT_PAYLOAD.sender.login}}
             at {{ EVENT_PAYLOAD.pull_request.html_url }}
-      - uses: "Ilshidur/action-discord@0.3.0"
+      - uses: "Ilshidur/action-discord@0.3.2"
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         if: ${{ github.event_name == 'issues' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,17 +25,17 @@ jobs:
       new_release_notes: ${{ steps.semantic.outputs.new_release_notes }}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: "21"
+          distribution: "temurin"
       - run: gradle build test
-      - uses: cycjimmy/semantic-release-action@v2
+      - uses: cycjimmy/semantic-release-action@v4
         id: semantic
         with:
-          semantic_version: 17
+          semantic_version: 24
           extra_plugins: |
             @google/semantic-release-replace-plugin
             @semantic-release/git
@@ -59,10 +59,10 @@ jobs:
     if: ${{ needs.release.outputs.new_release_published == 'true' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/codingpot/github-org-member-manage-action
           tags: |
@@ -72,22 +72,22 @@ jobs:
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'application'
-	id 'io.freefair.lombok' version '6.2.0'
+	id 'io.freefair.lombok' version '8.+'
 }
 
 repositories {
@@ -33,6 +33,9 @@ application {
 
 test {
 	useJUnitPlatform()
+	jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+			'--add-opens', 'java.base/java.util=ALL-UNNAMED',
+			'--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED'
 }
 
 jar {

--- a/app/src/main/java/com/github/codingpot/github_org_member_manage_action/config/Diff.java
+++ b/app/src/main/java/com/github/codingpot/github_org_member_manage_action/config/Diff.java
@@ -10,8 +10,10 @@ import lombok.Data;
 public class Diff {
     /** Owners to be added. */
     private Set<String> newAdmins;
+
     /** Members to be added. */
     private Set<String> newMembers;
+
     /** Members to be removed from the org. */
     private Set<String> membersToBeDeleted;
 }

--- a/app/src/main/java/com/github/codingpot/github_org_member_manage_action/status/Status.java
+++ b/app/src/main/java/com/github/codingpot/github_org_member_manage_action/status/Status.java
@@ -8,6 +8,7 @@ import lombok.Value;
 public class Status {
     /** Contains the type of the Status. */
     StatusType type;
+
     /** This should be only populated when {@link #type} is not {@link StatusType#OK}. */
     Optional<String> errorMessage;
 

--- a/app/src/test/java/com/github/codingpot/github_org_member_manage_action/github/GitHubServiceV3ImplTest.java
+++ b/app/src/test/java/com/github/codingpot/github_org_member_manage_action/github/GitHubServiceV3ImplTest.java
@@ -22,7 +22,7 @@ class GitHubServiceV3ImplTest {
         final GitHub gitHub =
                 new GitHubBuilder().withOAuthToken(System.getenv("INPUT_GH_TOKEN")).build();
         GHOrganization ghOrg = gitHub.getOrganization("codingpot");
-        service = new GitHubServiceV3Impl(ghOrg, gitHub, /*isDryRun=*/ false);
+        service = new GitHubServiceV3Impl(ghOrg, gitHub, /* isDryRun= */ false);
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,9 @@
-plugins { id("com.diffplug.spotless") version "5.15.0" }
+plugins {
+    id("com.diffplug.spotless") version "7.+"
+    id("com.github.ben-manes.versions") version "+"
+}
+
+repositories { mavenCentral() }
 
 spotless {
     java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
기존 의존성들을 최신 버전으로 업그레이드하고 GitHub Actions 워크플로우를 개선했습니다.

주요 변경사항:
- Spotless 플러그인을 5.15.0에서 7.+로 업그레이드
- Gradle 래퍼를 7.2에서 8.14.3으로 업그레이드
- Lombok 플러그인을 6.2.0에서 8.+로 업그레이드
- GitHub Actions에서 Java 11을 Java 21로 업그레이드
- 모든 GitHub Actions을 최신 버전으로 업그레이드:
  - actions/checkout@v2 → v4
  - actions/setup-java@v2 → v4
  - docker/*-action@v1/v2 → v3/v5/v6
  - semantic-release-action@v2 → v4
- Java 21 호환성을 위해 테스트에 JVM 모듈 열기 플래그 추가
- 코드 포맷팅 규칙에 따라 자동 포맷팅 적용

이러한 업그레이드를 통해 보안성과 성능이 개선되었고, 최신 기능들을 사용할 수 있게 되었습니다.
